### PR TITLE
v1.0.4hotfix

### DIFF
--- a/frontend/src/components/columns.tsx
+++ b/frontend/src/components/columns.tsx
@@ -162,7 +162,7 @@ export const columns: ColumnDef<Result>[] = [
         return <Skeleton className="h-9 rounded" />;
       }
       const numericValue = parseFloat(value);
-      const backgroundColor = getTailwindColor(numericValue, max, min);
+      const backgroundColor = getTailwindColor(numericValue, min, max);
       return (
         <div
           className={`${backgroundColor} p-2 rounded text-right font-medium`}


### PR DESCRIPTION
This pull request includes a small but important change to the `columns` definition in the `frontend/src/components/columns.tsx` file. The change corrects the order of parameters passed to the `getTailwindColor` function.

* [`frontend/src/components/columns.tsx`](diffhunk://#diff-78a9e909f703dc597df38a83f73931adf183ee93477c91a073bb333025092452L165-R165): Corrected the order of `min` and `max` parameters in the call to `getTailwindColor` to ensure the background color is calculated correctly.